### PR TITLE
fix: hide visit code and conceptId from the user

### DIFF
--- a/src/app/app-modules/core/components/diagnosis-search/diagnosis-search.component.html
+++ b/src/app/app-modules/core/components/diagnosis-search/diagnosis-search.component.html
@@ -50,19 +50,6 @@
         class="table table-striped"
         [dataSource]="diagnosis"
       >
-        <ng-container matColumnDef="ConceptID">
-          <th
-            mat-header-cell
-            style="border-bottom: none"
-            *matHeaderCellDef
-            mat-sort-header
-          >
-            {{ currentLanguageSet?.common?.ConceptID }}
-          </th>
-          <td mat-cell *matCellDef="let element">
-            {{ element?.conceptID }}
-          </td>
-        </ng-container>
         <ng-container matColumnDef="term">
           <th
             mat-header-cell

--- a/src/app/app-modules/core/components/diagnosis-search/diagnosis-search.component.ts
+++ b/src/app/app-modules/core/components/diagnosis-search/diagnosis-search.component.ts
@@ -44,7 +44,7 @@ export class DiagnosisSearchComponent implements OnInit, DoCheck, OnChanges {
   diagnosis$ = [];
   pageCount: any;
   selectedDiagnosisList: any = [];
-  displayedColumns: any = ['ConceptID', 'term', 'empty'];
+  displayedColumns: any = ['term', 'empty'];
   @ViewChild(MatPaginator) paginator: MatPaginator | null = null;
   diagnosis = new MatTableDataSource<any>();
 

--- a/src/app/app-modules/core/components/open-previous-visit-details/open-previous-visit-details.component.html
+++ b/src/app/app-modules/core/components/open-previous-visit-details/open-previous-visit-details.component.html
@@ -27,9 +27,6 @@
             <th style="width: 5%" id="visitcategory">
               {{ currentLanguageSet?.previousvisit?.visitcategorymmu }}
             </th>
-            <th style="width: 5%" id="visitcode">
-              {{ currentLanguageSet?.previousvisit?.visitcodemmu }}
-            </th>
             <th style="width: 15%" id="vitalDetails">Vital Details</th>
             <th style="width: 20%" id="diagnosis">Diagnosis</th>
             <th style="width: 30%" id="investigations">Investigations</th>
@@ -75,7 +72,7 @@
               >
                 {{ visit?.VisitCategory }}
               </td>
-              <td
+              <!-- <td
                 style="
                   max-width: 150px;
                   word-break: normal;
@@ -83,7 +80,7 @@
                 "
               >
                 {{ visit?.visitCode }}
-              </td>
+              </td> -->
               <td
                 style="width: 110px; word-break: normal; vertical-align: middle"
               >

--- a/src/app/app-modules/core/components/open-previous-visit-details/open-previous-visit-details.component.html
+++ b/src/app/app-modules/core/components/open-previous-visit-details/open-previous-visit-details.component.html
@@ -72,15 +72,6 @@
               >
                 {{ visit?.VisitCategory }}
               </td>
-              <!-- <td
-                style="
-                  max-width: 150px;
-                  word-break: normal;
-                  vertical-align: middle;
-                "
-              >
-                {{ visit?.visitCode }}
-              </td> -->
               <td
                 style="width: 110px; word-break: normal; vertical-align: middle"
               >

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/test-and-radiology/test-and-radiology.component.html
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/test-and-radiology/test-and-radiology.component.html
@@ -176,7 +176,6 @@
           <tr *ngFor="let fetosenseDataToShow of fetosenseData">
             <td>{{ fetosenseDataToShow.testTime }}</td>
             <td>{{ fetosenseDataToShow.testName }}</td>
-            <!-- <td>{{ fetosenseDataToShow.visitCode }}</td> -->
             <td>
               <!-- eslint-disable-next-line  @angular-eslint/template/click-events-have-key-events -->
               <em
@@ -339,7 +338,6 @@
         <tbody *ngIf="archivedResults?.length > 0">
           <tr *ngFor="let archivedReport of archivedResults">
             <td>{{ archivedReport.date | date: "dd/MM/yyyy" }}</td>
-            <!-- <td>{{ archivedReport.visitCode }}</td> -->
             <td>
               <!-- eslint-disable-next-line  @angular-eslint/template/click-events-have-key-events -->
               <em
@@ -362,16 +360,6 @@
             </h4>
           </header>
         </div>
-        <!-- <div
-          class="col-xs-12 col-sm-12 col-md-4 col-lg-4"
-          *ngIf="archivedLabResults?.length > 0"
-        >
-          <h4>
-            <strong> {{ current_language_set?.Reports?.visitcode }}: </strong
-            >{{ visitCode }}
-          </h4>
-        </div> -->
-
         <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 pull-right">
           <mat-form-field id="filterbox" class="pull-right">
             <input
@@ -528,15 +516,6 @@
               </h4>
             </header>
           </div>
-          <!-- <div
-            class="col-xs-12 col-sm-12 col-md-4 col-lg-4"
-            *ngIf="archivedRadiologyResults.length > 0"
-          >
-            <h4>
-              <strong> {{ current_language_set?.Reports?.visitcode }} : </strong
-              >{{ visitCode }}
-            </h4>
-          </div> -->
         </div>
         <div class="clearfix"></div>
         <div class="m-t-20 overflow">

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/test-and-radiology/test-and-radiology.component.html
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/test-and-radiology/test-and-radiology.component.html
@@ -159,9 +159,6 @@
           <th style="width: 20%" id="testName">
             {{ current_language_set?.labTechnicianData.testName }}
           </th>
-          <th style="width: 20%" id="visitcode">
-            {{ current_language_set?.Reports?.visitcode }}
-          </th>
           <th style="width: 20%" id="view">
             {{ current_language_set?.Reports?.view }}
           </th>
@@ -179,7 +176,7 @@
           <tr *ngFor="let fetosenseDataToShow of fetosenseData">
             <td>{{ fetosenseDataToShow.testTime }}</td>
             <td>{{ fetosenseDataToShow.testName }}</td>
-            <td>{{ fetosenseDataToShow.visitCode }}</td>
+            <!-- <td>{{ fetosenseDataToShow.visitCode }}</td> -->
             <td>
               <!-- eslint-disable-next-line  @angular-eslint/template/click-events-have-key-events -->
               <em
@@ -327,7 +324,7 @@
       >
         <tr>
           <th id="date">{{ current_language_set?.casesheet?.date }}</th>
-          <th id="visitcode">{{ current_language_set?.Reports?.visitcode }}</th>
+          <!-- <th id="visitcode">{{ current_language_set?.Reports?.visitcode }}</th> -->
           <th id="view">{{ current_language_set?.Reports?.view }}</th>
         </tr>
         <tbody *ngIf="archivedResults?.length === 0">
@@ -342,7 +339,7 @@
         <tbody *ngIf="archivedResults?.length > 0">
           <tr *ngFor="let archivedReport of archivedResults">
             <td>{{ archivedReport.date | date: "dd/MM/yyyy" }}</td>
-            <td>{{ archivedReport.visitCode }}</td>
+            <!-- <td>{{ archivedReport.visitCode }}</td> -->
             <td>
               <!-- eslint-disable-next-line  @angular-eslint/template/click-events-have-key-events -->
               <em
@@ -365,7 +362,7 @@
             </h4>
           </header>
         </div>
-        <div
+        <!-- <div
           class="col-xs-12 col-sm-12 col-md-4 col-lg-4"
           *ngIf="archivedLabResults?.length > 0"
         >
@@ -373,7 +370,7 @@
             <strong> {{ current_language_set?.Reports?.visitcode }}: </strong
             >{{ visitCode }}
           </h4>
-        </div>
+        </div> -->
 
         <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 pull-right">
           <mat-form-field id="filterbox" class="pull-right">
@@ -531,7 +528,7 @@
               </h4>
             </header>
           </div>
-          <div
+          <!-- <div
             class="col-xs-12 col-sm-12 col-md-4 col-lg-4"
             *ngIf="archivedRadiologyResults.length > 0"
           >
@@ -539,7 +536,7 @@
               <strong> {{ current_language_set?.Reports?.visitcode }} : </strong
               >{{ visitCode }}
             </h4>
-          </div>
+          </div> -->
         </div>
         <div class="clearfix"></div>
         <div class="m-t-20 overflow">

--- a/src/app/app-modules/nurse-doctor/case-sheet/general-case-sheet/doctor-diagnosis-case-sheet/doctor-diagnosis-case-sheet.component.html
+++ b/src/app/app-modules/nurse-doctor/case-sheet/general-case-sheet/doctor-diagnosis-case-sheet/doctor-diagnosis-case-sheet.component.html
@@ -60,10 +60,6 @@
             <td>
               {{ beneficiaryDetails && beneficiaryDetails.beneficiaryID }}
             </td>
-            <th id="visitcodemmu">
-              {{ current_language_set?.previousvisit?.visitcodemmu }}:
-            </th>
-            <td>{{ beneficiaryDetails && beneficiaryDetails.visitCode }}</td>
           </tr>
           <tr>
             <th id="name">{{ current_language_set?.casesheet?.name }}:</th>

--- a/src/app/app-modules/nurse-doctor/quick-consult/quick-consult.component.html
+++ b/src/app/app-modules/nurse-doctor/quick-consult/quick-consult.component.html
@@ -41,19 +41,6 @@
                   </td>
                 </ng-container>
 
-                <ng-container matColumnDef="ConceptID">
-                  <th
-                    mat-header-cell
-                    style="border-bottom: none"
-                    *matHeaderCellDef
-                    mat-sort-header
-                  >
-                    {{ currentLanguageSet?.common?.ConceptID }}
-                  </th>
-                  <td mat-cell *matCellDef="let element">
-                    {{ element.conceptID }}
-                  </td>
-                </ng-container>
 
                 <ng-container matColumnDef="description">
                   <th

--- a/src/app/app-modules/nurse-doctor/quick-consult/quick-consult.component.ts
+++ b/src/app/app-modules/nurse-doctor/quick-consult/quick-consult.component.ts
@@ -165,7 +165,7 @@ export class QuickConsultComponent
   rbsTestResultSubscription!: Subscription;
   rbsTestResultCurrent: any;
 
-  displayedColumns: any = ['chiefcomplaint', 'ConceptID', 'description'];
+  displayedColumns: any = ['chiefcomplaint', 'description'];
 
   dataSource = new MatTableDataSource<any>();
 

--- a/src/app/app-modules/nurse-doctor/visit-details/visit-details/visit-details.component.html
+++ b/src/app/app-modules/nurse-doctor/visit-details/visit-details/visit-details.component.html
@@ -25,18 +25,6 @@
     </div>
   </ng-container>
 
-  <div
-    class="col-xs-12 col-sm-6 col-md-4 col-lg-4 box"
-    *ngIf="mode?.toLowerCase() === 'view'"
-  >
-    <mat-form-field class="input-full-width">
-      <mat-label class="mat-label-text">{{
-        currentLanguageSet?.Reports?.visitcode
-      }}</mat-label>
-      <input matInput name="visitCode" formControlName="visitCode" />
-    </mat-form-field>
-  </div>
-
   <div class="col-xs-12 col-sm-6 col-md-4 col-lg-4 box">
     <mat-form-field [style.width]="'100%'">
       <mat-label class="mat-label-text">{{


### PR DESCRIPTION
## 📋 Description

JIRA ID: 1539, 1543

Hides unnecessary info visit code and concept id from the user 

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [x] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed the "ConceptID" column from diagnosis search and quick consult tables.
  - Removed the "Visit Code" column and related data from previous visit details, test and radiology reports, doctor diagnosis case sheet, and beneficiary details views.
  - Eliminated the visit code input field from the visit details view.
  - The user interface is now simplified, with visit code and concept ID information no longer displayed in the affected sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->